### PR TITLE
Fix INI generator logic for updating existing recipes

### DIFF
--- a/index.html
+++ b/index.html
@@ -727,7 +727,7 @@
                                     if (existingSection) {
                                         let productUpdated = false;
                                         let familyUpdated = false;
-                                        let caspianUpdated = false;
+                                        let caspianFound = false;
 
                                         let newSectionContent = existingSection.map(line => {
                                             if (line.startsWith('Product=')) {
@@ -738,21 +738,31 @@
                                                 familyUpdated = true;
                                                 return familyLine;
                                             }
-                                            if (line.startsWith('CaspianVTL=') && ['WATT_DARWIN', 'WATT', 'NESTAS_RAND_MID'].includes(familySelect.value)) {
-                                                caspianUpdated = true;
-                                                return `CaspianVTL=${vtlData.dataFileName}`;
+                                            if (line.startsWith('CaspianVTL=')) {
+                                                caspianFound = true;
+                                                // If new family needs it, update it. If not, remove it (return null).
+                                                if (['WATT_DARWIN', 'WATT', 'NESTAS_RAND_MID'].includes(familySelect.value)) {
+                                                    return `CaspianVTL=${vtlData.dataFileName}`;
+                                                } else {
+                                                    return null; // This will be filtered out later.
+                                                }
                                             }
                                             return line;
                                         });
 
                                         // Add lines that might be missing
-                                        if (!productUpdated) newSectionContent.push(productLine);
-                                        if (!familyUpdated) newSectionContent.push(familyLine);
-                                        if (['WATT_DARWIN', 'WATT', 'NESTAS_RAND_MID'].includes(familySelect.value) && !caspianUpdated) {
+                                        if (!productUpdated) {
+                                            newSectionContent.push(productLine);
+                                        }
+                                        if (!familyUpdated) {
+                                            newSectionContent.push(familyLine);
+                                        }
+                                        if (['WATT_DARWIN', 'WATT', 'NESTAS_RAND_MID'].includes(familySelect.value) && !caspianFound) {
                                             newSectionContent.push(`CaspianVTL=${vtlData.dataFileName}`);
                                         }
 
-                                        iniSections[recipeSection] = newSectionContent;
+                                        // Filter out removed lines and update the section
+                                        iniSections[recipeSection] = newSectionContent.filter(line => line !== null);
                                     } else {
                                         // If the section exists in [RECIPE] but not as its own section, create it
                                         iniSections[recipeSection] = sectionContent;


### PR DESCRIPTION
The previous logic for amending an existing recipe section did not correctly handle the `CaspianVTL` parameter. When switching to a family that does not require `CaspianVTL`, the old line was not removed.

This change implements a more robust update mechanism. It now correctly handles adding, updating, and removing the `Product`, `Family`, and `CaspianVTL` parameters based on the selected family's requirements, while preserving all other data and its relative order within the section.